### PR TITLE
First player cpu env vars

### DIFF
--- a/lib/env_var_parser.rb
+++ b/lib/env_var_parser.rb
@@ -1,11 +1,16 @@
 class EnvVarParser
-  attr_accessor :game_type, :color
-  @game_type = nil
+  attr_accessor :color, :player_one_type, :player_two_type, :cpu_difficulty_player_one, :cpu_difficulty_player_two
+
+  @player_one_type = nil
+  @player_two_type = nil
   @color = nil
+  @cpu_difficulty_player_one = :not_set
+  @cpu_difficulty_player_two = :not_set
 
     def initialize()
-      parse_game_type()
       parse_color_board()
+      @player_one_type = parse_player("PLAYER_ONE", @cpu_difficulty_player_one )
+      @player_two_type = parse_player("PLAYER_TWO", @cpu_difficulty_player_two)
     end
 
     def parse_color_board()
@@ -14,11 +19,16 @@ class EnvVarParser
       end
     end
 
-    def parse_game_type()
-      if ENV["GAME_TYPE"] == "hvh"
-        @game_type = "hvh"
-      elsif ENV["GAME_TYPE"] == "hvc"
-        @game_type = "hvc"
+    def parse_player(player, cpu_player_difficulty)
+      case ENV[player]
+      when "human"
+        :human
+      when "cpu_easy"
+        cpu_player_difficulty = :easy
+        :computer
+      when "cpu_hard"
+        cpu_player_difficulty = :hard
+        :computer
       end
     end
 

--- a/lib/game_config.rb
+++ b/lib/game_config.rb
@@ -16,12 +16,11 @@ class GameConfig
 
   def configure_color_board
     if @parsed_arguments.color == nil
-      set_color_board()
+      @color = @questions.yes_or_no?("COLOR?:")
     else
       @color = @parsed_arguments.color 
     end
   end
-
 
   def configure_all_players()
     #player 1
@@ -55,9 +54,6 @@ class GameConfig
     end
   end
 
-  def set_color_board
-      @color = @questions.yes_or_no?("COLOR?:")
-  end
 
   def configure_cpu_difficulty
     @questions.multichoice("CPU DIFFICULTY?:", [:easy, :hard])

--- a/lib/game_config.rb
+++ b/lib/game_config.rb
@@ -7,46 +7,55 @@ class GameConfig
     @cpu_difficulty_player_one = :not_set
     @cpu_difficulty_player_two = :not_set
     @questions = questions
+    @parsed_arguments = parsed_arguments
 
-    if parsed_arguments.color == nil
-      configure_color_board()
-    else
-      @color = parsed_arguments.color 
-    end
+    configure_color_board()
+    configure_all_players()
+  end
 
-    if parsed_arguments.game_type == nil
-      configure_game_type()
+
+  def configure_color_board
+    if @parsed_arguments.color == nil
+      set_color_board()
     else
-      @player_one_type = set_player_type(parsed_arguments, :player_one)
-      @player_two_type = set_player_type(parsed_arguments, :player_two)
+      @color = @parsed_arguments.color 
     end
   end
 
-  def set_player_type(parsed_arguments, player)
+
+  def configure_all_players()
+    #player 1
+    if @parsed_arguments.player_one_type == nil
+      configure_player_type(:player_one)
+    else
+      @player_one_type = @parsed_arguments.player_one_type
+      @cpu_difficulty_player_one = @parsed_arguments.cpu_difficulty_player_one
+    end
+    #player 2
+    if @parsed_arguments.player_two_type == nil
+      configure_player_type(:player_two)
+    else
+      @player_two_type = @parsed_arguments.player_two_type
+      @cpu_difficulty_player_two = @parsed_arguments.cpu_difficulty_player_two
+    end
+  end
+
+
+  def configure_player_type(player)
     if player == :player_one
-      :human
+      @player_one_type = @questions.multichoice("PLAYER 1 IS A:", [:human, :computer])
+      if @player_one_type == :computer
+        @cpu_difficulty_player_one = configure_cpu_difficulty()
+      end
     elsif player == :player_two
-      if parsed_arguments.game_type == "hvh"
-        :human
-      elsif parsed_arguments.game_type == "hvc"
-        :computer
+      @player_two_type = @questions.multichoice("PLAYER 2 IS A:", [:human, :computer])
+      if @player_two_type == :computer
+        @cpu_difficulty_player_two = configure_cpu_difficulty()
       end
     end
   end
 
-  def configure_game_type
-    @player_one_type = @questions.multichoice("PLAYER 1 IS A:", [:human, :computer])
-    if @player_one_type == :computer
-      @cpu_difficulty_player_one = configure_cpu_difficulty()
-    end
-
-    @player_two_type = @questions.multichoice("PLAYER 2 IS A:", [:human, :computer])
-    if @player_two_type == :computer
-      @cpu_difficulty_player_two = configure_cpu_difficulty()
-    end
-  end
-
-  def configure_color_board
+  def set_color_board
       @color = @questions.yes_or_no?("COLOR?:")
   end
 

--- a/spec/env_var_parser_spec.rb
+++ b/spec/env_var_parser_spec.rb
@@ -1,43 +1,56 @@
 require 'env_var_parser'
 
 describe "EnvVarParser" do
-  it "should set @game_type to nil if no env variable for game_type is passed" do
-    parsed_env_vars = EnvVarParser.new()
 
-    expect(parsed_env_vars.game_type).to be nil
-  end
+  describe "#parse_player" do
+    it "sets player to type nil if no env var is passed in" do
+      parsed_env_vars = EnvVarParser.new()
+      parsed_env_vars.parse_player("PLAYER_ONE", nil)
 
-  it "should set @game_type to value passed in" do
-    cached_game_type = ENV["GAME_TYPE"]
-    ENV["GAME_TYPE"] = "hvh"
-
-    parsed_env_vars = EnvVarParser.new()
-
-    expect(parsed_env_vars.game_type).to eq("hvh")
-
-    ENV["GAME_TYPE"] = cached_game_type
-  end
-
-
-  it "should set @color to nil if no color env var is passed in" do
-    cached_game_type = ENV["GAME_TYPE"]
-    ENV["GAME_TYPE"] = "hvc"
+      expect(parsed_env_vars.player_one_type).to eq(nil)
+    end
     
-    parsed_env_vars = EnvVarParser.new()
+    it "sets player to type human if env var is passed in" do
+      cached_player_one = ENV["PLAYER_ONE"]
+      ENV["PLAYER_ONE"] = 'human'
 
-    expect(parsed_env_vars.color).to eq(nil)
+      parsed_env_vars = EnvVarParser.new()
+
+      expect(parsed_env_vars.player_one_type).to eq(:human)
+      ENV["PLAYER_ONE"] = cached_player_one
+    end
     
-    ENV["GAME_TYPE"] = cached_game_type
-  end
-  
-  it "should set @color to true if env var is passed in" do
-    cached_color = ENV["COLOR"]
-    ENV["COLOR"] = 'true'
-    parsed_env_vars = EnvVarParser.new()
+    it "sets player to type computer if env var is passed in" do
+      cached_player_two = ENV["PLAYER_TWO"]
+      ENV["PLAYER_TWO"] = 'cpu_hard'
 
-    expect(parsed_env_vars.color).to eq(true)
+      parsed_env_vars = EnvVarParser.new()
 
-    ENV["COLOR"] = cached_color
+      expect(parsed_env_vars.player_two_type).to eq(:computer)
+      ENV["PLAYER_TWO"] = cached_player_two
+    end
   end
+
+  describe "#parse_color_board" do
+    it "should set @color to nil if no color env var is passed in" do
+      parsed_env_vars = EnvVarParser.new()
+
+      parsed_env_vars.parse_color_board()
+
+      expect(parsed_env_vars.color).to eq(nil)
+    end
+
+    it "should set @color to true if env var is passed in" do
+      cached_color = ENV["COLOR"]
+      ENV["COLOR"] = 'true'
+      parsed_env_vars = EnvVarParser.new()
+
+      parsed_env_vars.parse_color_board()
+
+      expect(parsed_env_vars.color).to eq(true)
+
+      ENV["COLOR"] = cached_color
+    end
+end
   
 end

--- a/spec/game_config_spec.rb
+++ b/spec/game_config_spec.rb
@@ -3,7 +3,7 @@ require 'questions'
 require 'env_var_parser'
 
 describe GameConfig do
-  describe "#configure_game_type" do
+  describe "#configure_player_type" do
     it 'when user picks 1 Human for player 2 both players are human' do
       questions = Questions.new
       parsed_env_vars = EnvVarParser.new()
@@ -29,41 +29,8 @@ describe GameConfig do
     end
   end
 
-  describe "#set_player_type" do
-    it "sets player_one & player_two type to :human if given hvh flag" do
-      cached_game_type = ENV["GAME_TYPE"]
-      ENV["GAME_TYPE"] = "hvh"
-
-      questions = Questions.new
-      parsed_env_vars = EnvVarParser.new()
-      
-      allow(questions).to receive(:yes_or_no?).and_return(true)
-      game_config = GameConfig.new(questions, parsed_env_vars)
-
-      expect(game_config.player_one_type).to eq(:human)
-      expect(game_config.player_two_type).to eq(:human)
-
-      ENV["GAME_TYPE"] = cached_game_type
-    end
-    
-    it "sets player_two type to :computer if given hvc flag" do
-      cached_game_type = ENV["GAME_TYPE"]
-      ENV["GAME_TYPE"] = "hvc"
-      
-      questions = Questions.new
-      parsed_env_vars = EnvVarParser.new()
-      
-      allow(questions).to receive(:yes_or_no?).and_return(true)
-      game_config = GameConfig.new(questions, parsed_env_vars)
-
-      expect(game_config.player_two_type).to eq(:computer)
-
-      ENV["GAME_TYPE"] = cached_game_type
-    end
-  end
-
   describe "#configure_color_board" do
-    it 'when user picks 1 sets @color to true' do
+    it 'when user picks yes sets @color to true' do
       questions = Questions.new
       parsed_env_vars = EnvVarParser.new()
 
@@ -72,6 +39,22 @@ describe GameConfig do
       game_config = GameConfig.new(questions, parsed_env_vars)
 
       expect(game_config.color).to eq(true)
+    end
+  end
+  
+  describe "#configure_cpu_difficulty" do
+    it 'returns easy or hard' do
+      questions = Questions.new
+      parsed_env_vars = EnvVarParser.new()
+
+      allow(questions).to receive(:yes_or_no?).and_return(true)
+      allow(questions).to receive(:multichoice).and_return(1)
+      allow(questions).to receive(:multichoice).and_return(2)
+      allow(questions).to receive(:multichoice).and_return(:easy)
+      game_config = GameConfig.new(questions, parsed_env_vars)
+      expected_answer = game_config.configure_cpu_difficulty()
+
+      expect(expected_answer).to eq(:easy)
     end
   end
 


### PR DESCRIPTION
- Removed GAME_TYPE as an env var
- User can now set each player individually in env vars: 
    `PLAYER_ONE=human PLAYER_TWO=cpu_hard COLOR=true ruby bin/tictactoe.rb`