### PR TITLE
refactor cpu logic to use logic from ttt gem

### DIFF
--- a/lib/computer_logic/computer_logic_hard.rb
+++ b/lib/computer_logic/computer_logic_hard.rb
@@ -5,13 +5,8 @@ class ComputerLogicHard
     end
 
     def cpu_turn
-      if cpu_check_for_wins_or_blocks_horizontally?(:X)
-      elsif cpu_check_for_wins_or_blocks_vertically?(:X)
-      elsif cpu_check_for_wins_or_blocks_diagonally?(:X)
-  
-      elsif cpu_check_for_wins_or_blocks_horizontally?(:O)
-      elsif cpu_check_for_wins_or_blocks_vertically?(:O)
-      elsif cpu_check_for_wins_or_blocks_diagonally?(:O)
+      if cpu_check_for_wins_or_blocks(:O)
+      elsif cpu_check_for_wins_or_blocks(:X)
       else
          cpu_take_open_space()
       end
@@ -21,72 +16,22 @@ class ComputerLogicHard
       random_open_space = @game_logic.open_spaces().sample
       @game_logic.take_turn(random_open_space) 
     end
-  
-  def cpu_check_for_wins_or_blocks_horizontally?(player_symbol)
-    if @game_logic.board_spaces[0] == player_symbol && @game_logic.board_spaces[1] == player_symbol && @game_logic.board_spaces[2] == :empty
-      @game_logic.board_spaces[2] = :O
-      true
-    elsif @game_logic.board_spaces[1] == player_symbol && @game_logic.board_spaces[2] == player_symbol && @game_logic.board_spaces[0] == :empty
-      @game_logic.board_spaces[0] = :O
-      true
-    elsif @game_logic.board_spaces[3] == player_symbol && @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[5] == :empty
-      @game_logic.board_spaces[5] = :O
-      true
-    elsif @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[5] == player_symbol && @game_logic.board_spaces[3] == :empty
-      @game_logic.board_spaces[3] = :O
-      true
-    elsif @game_logic.board_spaces[6] == player_symbol && @game_logic.board_spaces[7] == player_symbol && @game_logic.board_spaces[8] == :empty
-      @game_logic.board_spaces[8] = :O
-      true
-    elsif @game_logic.board_spaces[7] == player_symbol && @game_logic.board_spaces[8] == player_symbol && @game_logic.board_spaces[6] == :empty
-      @game_logic.board_spaces[6] = :O
-      true
-    else
-      false
-    end
-  end
-  
-  def cpu_check_for_wins_or_blocks_vertically?(player_symbol)
-    if @game_logic.board_spaces[0] == player_symbol && @game_logic.board_spaces[3] == player_symbol && @game_logic.board_spaces[6] == :empty
-      @game_logic.board_spaces[6] = :O
-      true
-    elsif @game_logic.board_spaces[3] == player_symbol && @game_logic.board_spaces[6] == player_symbol && @game_logic.board_spaces[0] == :empty
-      @game_logic.board_spaces[0] = :O
-      true
-    elsif @game_logic.board_spaces[1] == player_symbol && @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[7] == :empty
-      @game_logic.board_spaces[7] = :O
-      true
-    elsif @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[7] == player_symbol && @game_logic.board_spaces[1] == :empty
-      @game_logic.board_spaces[1] = :O
-      true
-    elsif @game_logic.board_spaces[2] == player_symbol && @game_logic.board_spaces[5] == player_symbol && @game_logic.board_spaces[8] == :empty
-      @game_logic.board_spaces[8] = :O
-      true
-    elsif @game_logic.board_spaces[5] == player_symbol && @game_logic.board_spaces[8] == player_symbol && @game_logic.board_spaces[2] == :empty
-      @game_logic.board_spaces[2] = :O
-      true
-    else
-      false
-    end
-  end
 
-
-  def cpu_check_for_wins_or_blocks_diagonally?(player_symbol)
-    if @game_logic.board_spaces[0] == player_symbol && @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[8] == :empty
-      @game_logic.board_spaces[8] = :O
-      true
-    elsif @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[8] == player_symbol && @game_logic.board_spaces[0] == :empty
-      @game_logic.board_spaces[0] = :O
-      true
-    elsif @game_logic.board_spaces[2] == player_symbol && @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[6] == :empty
-      @game_logic.board_spaces[6] = :O
-      true
-    elsif @game_logic.board_spaces[6] == player_symbol && @game_logic.board_spaces[4] == player_symbol && @game_logic.board_spaces[2] == :empty
-      @game_logic.board_spaces[2] = :O
-      true
-    else
-      false
+def cpu_check_for_wins_or_blocks(player_symbol)
+  move = false
+  for win_combo in @game_logic.win_combos do
+    row = Array.new
+    for index in win_combo do
+      row.append(@game_logic.board_spaces[index])
+    end
+    if (row.count(player_symbol) == 2) && (row.include?(:empty))
+      move = win_combo[row.index(:empty)]
+      @game_logic.board_spaces[move] = :O
+      move = true
     end
   end
+  move
+end
+
 
 end

--- a/lib/game_logic.rb
+++ b/lib/game_logic.rb
@@ -1,19 +1,19 @@
 class GameLogic
-  attr_reader :board_spaces
+  attr_reader :board_spaces, :win_combos
 
-  WIN_COMBOS = [
-    [0,1,2], # top_row
-    [3,4,5], # middle_row
-    [6,7,8], # bottom_row
-    [0,3,6], # left_column
-    [1,4,7], # center_column
-    [2,5,8], # right_column
-    [0,4,8], # left_diagonal
-    [6,4,2] # right_diagonal
-  ]
-
+  
   def initialize()
     @board_spaces = Array.new(9, :empty)
+    @win_combos = [
+      [0,1,2], # top_row
+      [3,4,5], # middle_row
+      [6,7,8], # bottom_row
+      [0,3,6], # left_column
+      [1,4,7], # center_column
+      [2,5,8], # right_column
+      [0,4,8], # left_diagonal
+      [6,4,2] # right_diagonal
+    ]
   end
 
   def take_turn(choice)
@@ -27,7 +27,7 @@ class GameLogic
 
   def is_there_winner?
     winner_symbol = nil
-    for win_combo in WIN_COMBOS do
+    for win_combo in @win_combos do
       row = Array.new
       for index in win_combo do
         row.append(@board_spaces[index])

--- a/spec/computer_logic_hard_spec.rb
+++ b/spec/computer_logic_hard_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[0] = :X
       game.board_spaces[1] = :X
 
-      computer_logic.cpu_check_for_wins_or_blocks_horizontally?(:X)
+      computer_logic.cpu_check_for_wins_or_blocks(:X)
 
       expect(game.board_spaces[2]).to eq(:O)
     end
@@ -46,7 +46,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[1] = :X
       game.board_spaces[2] = :X
 
-      computer_logic.cpu_check_for_wins_or_blocks_horizontally?(:X)
+      computer_logic.cpu_check_for_wins_or_blocks(:X)
 
       expect(game.board_spaces[0]).to eq(:O)
     end
@@ -60,7 +60,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[0] = :X
       game.board_spaces[3] = :X
 
-      computer_logic.cpu_check_for_wins_or_blocks_vertically?(:X)
+      computer_logic.cpu_check_for_wins_or_blocks(:X)
 
       expect(game.board_spaces[6]).to eq(:O)
     end
@@ -72,7 +72,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[4] = :X
       game.board_spaces[7] = :X
 
-      computer_logic.cpu_check_for_wins_or_blocks_vertically?(:X)
+      computer_logic.cpu_check_for_wins_or_blocks(:X)
 
       expect(game.board_spaces[1]).to eq(:O)
     end
@@ -86,7 +86,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[0] = :X
       game.board_spaces[4] = :X
 
-      computer_logic.cpu_check_for_wins_or_blocks_diagonally?(:X)
+      computer_logic.cpu_check_for_wins_or_blocks(:X)
 
       expect(game.board_spaces[8]).to eq(:O)
     end
@@ -98,7 +98,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[2] = :X
       game.board_spaces[4] = :X
 
-      computer_logic.cpu_check_for_wins_or_blocks_diagonally?(:X)
+      computer_logic.cpu_check_for_wins_or_blocks(:X)
 
       expect(game.board_spaces[6]).to eq(:O)
     end
@@ -112,7 +112,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[0] = :O
       game.board_spaces[1] = :O
 
-      computer_logic.cpu_check_for_wins_or_blocks_horizontally?(:O)
+      computer_logic.cpu_check_for_wins_or_blocks(:O)
 
       expect(game.board_spaces[2]).to eq(:O)
     end
@@ -126,7 +126,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[0] = :O
       game.board_spaces[3] = :O
 
-      computer_logic.cpu_check_for_wins_or_blocks_vertically?(:O)
+      computer_logic.cpu_check_for_wins_or_blocks(:O)
 
       expect(game.board_spaces[6]).to eq(:O)
     end
@@ -140,7 +140,7 @@ RSpec.describe ComputerLogicHard do
       game.board_spaces[2] = :O
       game.board_spaces[4] = :O
 
-      computer_logic.cpu_check_for_wins_or_blocks_diagonally?(:O)
+      computer_logic.cpu_check_for_wins_or_blocks(:O)
 
       expect(game.board_spaces[6]).to eq(:O)
     end


### PR DESCRIPTION
- Implemented a refactor for cpu computer logic
- Its the same logic from the ttt gem I'm working on. The logic is a little different in this TTT app than from the gem in the following ways: 
 in the gem, the best_move method returns the int value of the best move but in the TTT app, 'cpu_turn' directly sets the board with a space. So had to make some minor changes to the logic here in the TTT app. I later remembered that Tyler mentioned I was going to replace my CPU logic here with the gem but that logic will not work because of how the TTT app is currently using 'cpu_turn'. Will bring this up during standup tomorrow. 